### PR TITLE
Added the board app to settings.py

### DIFF
--- a/shiftboard/settings.py
+++ b/shiftboard/settings.py
@@ -37,6 +37,7 @@ ALLOWED_HOSTS = []
 # Application definition
 
 INSTALLED_APPS = [
+    'board.apps.BoardConfig',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',


### PR DESCRIPTION
Added `board.apps.BoardConfig` to `INSTALLED_APPS`. The allowed hosts parts probably needs configuration as well but that can be tested after we combine things together.